### PR TITLE
fix: xmnote enable status; add: author field

### DIFF
--- a/plugins/exporter.koplugin/target/xmnote.lua
+++ b/plugins/exporter.koplugin/target/xmnote.lua
@@ -79,6 +79,7 @@ end
 function XMNoteExporter:createRequestBody(booknotes)
     local book = {
         title = booknotes.title or "",
+        author = booknotes.author or "",
         type = 1,
         locationUnit = 1,
     }
@@ -151,10 +152,13 @@ end
 
 
 function XMNoteExporter:isReadyToExport()
-    return true
+    if self.settings.ip then return true end
+    return false
 end
 
 function XMNoteExporter:export(t)
+    if not self:isReadyToExport() then return false end
+
     for _, booknotes in ipairs(t) do
         local ok = self:createHighlights(booknotes)
         if not ok then return false end


### PR DESCRIPTION
I recently added Xmnote support for koreader. When I was ready to contribute to koreader, I came across your PR. Great job!
Since I also write code, I believe there are a few things that should be merged in the PR:
1. The author field in highlights.
2. In `isReadyToExport`, check if the `ip` is set. If not, then the user cannot enable xmnote export.